### PR TITLE
feat: allow adding more trusted principals to task role

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,26 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.44.0
     hooks:
       - id: terraform_fmt
+      - id: terraform_validate
       - id: terraform_docs
+      - id: terraform_tflint
+        args:
+          - '--args=--only=terraform_deprecated_interpolation'
+          - '--args=--only=terraform_deprecated_index'
+          - '--args=--only=terraform_unused_declarations'
+          - '--args=--only=terraform_comment_syntax'
+          - '--args=--only=terraform_documented_outputs'
+          - '--args=--only=terraform_documented_variables'
+          - '--args=--only=terraform_typed_variables'
+          - '--args=--only=terraform_module_pinned_source'
+          - '--args=--only=terraform_naming_convention'
+          - '--args=--only=terraform_required_version'
+          - '--args=--only=terraform_required_providers'
+          - '--args=--only=terraform_standard_module_structure'
+          - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.3.0
     hooks:
       - id: check-merge-conflict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="v2.25.0"></a>
+## [v2.25.0] - 2020-11-10
+
+- feat: Added support for Fargate Spot ([#164](https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/164))
+
+
 <a name="v2.24.0"></a>
 ## [v2.24.0] - 2020-09-01
 
@@ -340,7 +346,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.24.0...HEAD
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.25.0...HEAD
+[v2.25.0]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.24.0...v2.25.0
 [v2.24.0]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.23.0...v2.24.0
 [v2.23.0]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.22.0...v2.23.0
 [v2.22.0]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.21.0...v2.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="v2.26.0"></a>
+## [v2.26.0] - 2020-11-13
+
+- feat: allow for extra_container_definitions ([#162](https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/162))
+
+
 <a name="v2.25.0"></a>
 ## [v2.25.0] - 2020-11-10
 
@@ -346,7 +352,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.25.0...HEAD
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.26.0...HEAD
+[v2.26.0]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.25.0...v2.26.0
 [v2.25.0]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.24.0...v2.25.0
 [v2.24.0]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.23.0...v2.24.0
 [v2.23.0]: https://github.com/terraform-aws-modules/terraform-aws-atlantis/compare/v2.22.0...v2.23.0

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ allow_github_webhooks        = true
 | start\_timeout | Time duration (in seconds) to wait before giving up on resolving dependencies for a container | `number` | `30` | no |
 | stop\_timeout | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own | `number` | `30` | no |
 | tags | A map of tags to use on all resources | `map(string)` | `{}` | no |
-| trusted\_principals | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | `list(string)` | <pre>[]</pre> | no |
+| trusted\_principals | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | `list(string)` | `[]` | no |
 | ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | <pre>list(object({<br>    name      = string<br>    hardLimit = number<br>    softLimit = number<br>  }))</pre> | `null` | no |
 | user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set. | `string` | `null` | no |
 | volumes\_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume) | <pre>list(object({<br>    sourceContainer = string<br>    readOnly        = bool<br>  }))</pre> | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ allow_github_webhooks        = true
 | ecs\_task\_memory | The amount (in MiB) of memory used by the task | `number` | `512` | no |
 | entrypoint | The entry point that is passed to the container | `list(string)` | `null` | no |
 | essential | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `true` | no |
+| extra\_container\_definitions | A list of valid container definitions provided as a single valid JSON document. These will be provided as supplimentary to the main Atlantis container definition | `list(any)` | `[]` | no |
 | firelens\_configuration | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | <pre>object({<br>    type    = string<br>    options = map(string)<br>  })</pre> | `null` | no |
 | github\_webhooks\_cidr\_blocks | List of CIDR blocks used by GitHub webhooks | `list(string)` | <pre>[<br>  "140.82.112.0/20",<br>  "185.199.108.0/22",<br>  "192.30.252.0/22"<br>]</pre> | no |
 | internal | Whether the load balancer is internal or external | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ allow_github_webhooks        = true
 | start\_timeout | Time duration (in seconds) to wait before giving up on resolving dependencies for a container | `number` | `30` | no |
 | stop\_timeout | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own | `number` | `30` | no |
 | tags | A map of tags to use on all resources | `map(string)` | `{}` | no |
+| trusted\_principals | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | `list(string)` | <pre>[]</pre> | no |
 | ulimits | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | <pre>list(object({<br>    name      = string<br>    hardLimit = number<br>    softLimit = number<br>  }))</pre> | `null` | no |
 | user | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set. | `string` | `null` | no |
 | volumes\_from | A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume) | <pre>list(object({<br>    sourceContainer = string<br>    readOnly        = bool<br>  }))</pre> | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains Terraform infrastructure code which creates AWS resourc
 - [AWS Elastic Cloud Service (ECS)](https://aws.amazon.com/ecs/) and [AWS Fargate](https://aws.amazon.com/fargate/) running Atlantis Docker image
 - AWS Parameter Store to keep secrets and access them in ECS task natively
 
-[AWS Fargate](https://aws.amazon.com/fargate/) is used instead of AWS ECS/EC2 to reduce the bill, and it is also a cool AWS service.
+[AWS Fargate](https://aws.amazon.com/fargate/) with optional support for [Fargate Spot](https://aws.amazon.com/blogs/aws/aws-fargate-spot-now-generally-available/) is used to reduce the bill, and it is also a cool AWS service.
 
 Depending on which SCM system you use, Github repositories or Gitlab projects has to be configured to post events to Atlantis webhook URL.
 
@@ -166,15 +166,16 @@ allow_github_webhooks        = true
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7, < 0.14 |
-| aws | >= 2.68, < 4.0 |
+| terraform | >= 0.12.7 |
+| aws | >= 2.68 |
+| random | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.68, < 4.0 |
-| random | n/a |
+| aws | >= 2.68 |
+| random | >= 2.0 |
 
 ## Inputs
 
@@ -228,6 +229,7 @@ allow_github_webhooks        = true
 | custom\_environment\_variables | List of additional environment variables the container will use (list should contain maps with `name` and `value`) | <pre>list(object(<br>    {<br>      name  = string<br>      value = string<br>    }<br>  ))</pre> | `[]` | no |
 | docker\_labels | The configuration options to send to the `docker_labels` | `map(string)` | `null` | no |
 | ecs\_container\_insights | Controls if ECS Cluster has container insights enabled | `bool` | `false` | no |
+| ecs\_fargate\_spot | Whether to run ECS Fargate Spot or not | `bool` | `false` | no |
 | ecs\_service\_assign\_public\_ip | Should be true, if ECS service is using public subnets (more info: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_cannot_pull_image.html) | `bool` | `false` | no |
 | ecs\_service\_deployment\_maximum\_percent | The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment | `number` | `200` | no |
 | ecs\_service\_deployment\_minimum\_healthy\_percent | The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment | `number` | `50` | no |

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -27,13 +27,16 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.7 |
+| aws | >= 2.68 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 2.68 |
 
 ## Inputs
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -46,6 +46,7 @@ No requirements.
 | github\_token | Github token | `string` | n/a | yes |
 | github\_user | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
 | region | AWS region where resources will be created | `string` | `"us-east-1"` | no |
+| trusted\_principals | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | | `list(string)` | n/a | no |
 
 ## Outputs
 

--- a/examples/github-complete/README.md
+++ b/examples/github-complete/README.md
@@ -49,7 +49,7 @@ Go to https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/settin
 | github\_token | Github token | `string` | n/a | yes |
 | github\_user | Github user for Atlantis to utilize when performing Github activities | `string` | n/a | yes |
 | region | AWS region where resources will be created | `string` | `"us-east-1"` | no |
-| trusted\_principals | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | | `list(string)` | n/a | no |
+| trusted\_principals | A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -59,6 +59,9 @@ module "atlantis" {
     hardLimit = 16384
   }]
 
+  # Security
+  trusted_principals = ["ssm.amazonaws.com"] # Convenient if you want to enable SSM access into Atlantis for troubleshooting etc
+
   # DNS
   route53_zone_name = var.domain
 

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -60,7 +60,7 @@ module "atlantis" {
   }]
 
   # Security
-  trusted_principals = ["ssm.amazonaws.com"] # Convenient if you want to enable SSM access into Atlantis for troubleshooting etc
+  trusted_principals = var.trusted_principals
 
   # DNS
   route53_zone_name = var.domain

--- a/examples/github-complete/main.tf
+++ b/examples/github-complete/main.tf
@@ -97,13 +97,13 @@ module "github_repository_webhook" {
   webhook_url    = module.atlantis.atlantis_url_events
   webhook_secret = module.atlantis.webhook_secret
 }
+
 ################################################################################
 # ALB Access Log Bucket + Policy
 ################################################################################
-
 module "atlantis_access_log_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 1.9"
+  version = ">= 1.9"
 
   bucket = "${data.aws_caller_identity.current.account_id}-atlantis-access-logs-${data.aws_region.current.name}"
 

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -5,3 +5,4 @@ github_organization = "myorg"
 github_user = "atlantis"
 github_token = "mygithubpersonalaccesstokenforatlantis"
 allowed_repo_names = ["repo1", "repo2"]
+trusted_principals = ["xyz.amazonaws.com"]

--- a/examples/github-complete/terraform.tfvars.sample
+++ b/examples/github-complete/terraform.tfvars.sample
@@ -5,4 +5,4 @@ github_organization = "myorg"
 github_user = "atlantis"
 github_token = "mygithubpersonalaccesstokenforatlantis"
 allowed_repo_names = ["repo1", "repo2"]
-trusted_principals = ["xyz.amazonaws.com"]
+trusted_principals = ["ssm.amazonaws.com"] # Convenient if you want to enable SSM access into Atlantis for troubleshooting etc

--- a/examples/github-complete/variables.tf
+++ b/examples/github-complete/variables.tf
@@ -33,3 +33,8 @@ variable "allowed_repo_names" {
   description = "Repositories that Atlantis will listen for events from and a webhook will be installed"
   type        = list(string)
 }
+
+variable "trusted_principals" {
+  description = "A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role"
+  type        = list(string)
+}

--- a/examples/github-complete/versions.tf
+++ b/examples/github-complete/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_version = ">= 0.12.7"
 
   required_providers {
-    aws    = ">= 2.68"
-    random = ">= 2.0"
+    aws = ">= 2.68"
   }
 }

--- a/examples/github-repository-webhook/README.md
+++ b/examples/github-repository-webhook/README.md
@@ -19,7 +19,10 @@ Note that this example may create resources which cost money. Run `terraform des
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.7 |
+| aws | >= 2.68 |
 
 ## Providers
 

--- a/examples/github-repository-webhook/main.tf
+++ b/examples/github-repository-webhook/main.tf
@@ -14,10 +14,10 @@ module "github_repository_webhook" {
   github_token        = var.github_token
   github_organization = var.github_organization
 
-  // Fetching these attributes from created already Atlantis Terraform state file
-  //
-  // This assumes that you are the owner of these repositories and they are available at:
-  // https://github.com/mygithubusername/awesome-repo and https://github.com/mygithubusername/another-awesome-repo
+  # Fetching these attributes from created already Atlantis Terraform state file
+  #
+  # This assumes that you are the owner of these repositories and they are available at:
+  # https://github.com/mygithubusername/awesome-repo and https://github.com/mygithubusername/another-awesome-repo
   atlantis_allowed_repo_names = data.terraform_remote_state.atlantis.outputs.atlantis_allowed_repo_names
 
   webhook_url    = data.terraform_remote_state.atlantis.outputs.atlantis_url_events

--- a/examples/github-repository-webhook/versions.tf
+++ b/examples/github-repository-webhook/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_version = ">= 0.12.7"
 
   required_providers {
-    aws    = ">= 2.68"
-    random = ">= 2.0"
+    aws = ">= 2.68"
   }
 }

--- a/examples/gitlab-repository-webhook/README.md
+++ b/examples/gitlab-repository-webhook/README.md
@@ -17,7 +17,10 @@ Note that this example may create resources which cost money. Run `terraform des
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.7 |
+| aws | >= 2.68 |
 
 ## Providers
 

--- a/examples/gitlab-repository-webhook/main.tf
+++ b/examples/gitlab-repository-webhook/main.tf
@@ -14,7 +14,7 @@ module "gitlab_repository_webhook" {
   gitlab_token    = var.gitlab_token
   gitlab_base_url = var.gitlab_base_url
 
-  // Fetching these attributes from created already Atlantis Terraform state file
+  # Fetching these attributes from created already Atlantis Terraform state file
   atlantis_allowed_repo_names = data.terraform_remote_state.atlantis.outputs.atlantis_allowed_repo_names
   webhook_url                 = data.terraform_remote_state.atlantis.outputs.atlantis_url_events
   webhook_secret              = data.terraform_remote_state.atlantis.outputs.webhook_secret

--- a/examples/gitlab-repository-webhook/versions.tf
+++ b/examples/gitlab-repository-webhook/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_version = ">= 0.12.7"
 
   required_providers {
-    aws    = ">= 2.68"
-    random = ">= 2.0"
+    aws = ">= 2.68"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -349,10 +349,16 @@ resource "aws_route53_record" "atlantis" {
 ###################
 module "ecs" {
   source  = "terraform-aws-modules/ecs/aws"
-  version = "v2.3.0"
+  version = "v2.5.0"
 
   name               = var.name
   container_insights = var.ecs_container_insights
+
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy = {
+    capacity_provider = var.ecs_fargate_spot ? "FARGATE_SPOT" : "FARGATE"
+  }
 
   tags = local.tags
 }
@@ -386,7 +392,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
   policy_arn = element(var.policies_arn, count.index)
 }
 
-// ref: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html
+# ref: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html
 data "aws_iam_policy_document" "ecs_task_access_secrets" {
   statement {
     effect = "Allow"
@@ -576,7 +582,7 @@ resource "aws_ecs_service" "atlantis" {
     data.aws_ecs_task_definition.atlantis.revision,
   )}"
   desired_count                      = var.ecs_service_desired_count
-  launch_type                        = "FARGATE"
+  launch_type                        = var.ecs_fargate_spot ? null : "FARGATE"
   deployment_maximum_percent         = var.ecs_service_deployment_maximum_percent
   deployment_minimum_healthy_percent = var.ecs_service_deployment_minimum_healthy_percent
 
@@ -590,6 +596,14 @@ resource "aws_ecs_service" "atlantis" {
     container_name   = var.name
     container_port   = var.atlantis_port
     target_group_arn = element(module.alb.target_group_arns, 0)
+  }
+
+  dynamic "capacity_provider_strategy" {
+    for_each = var.ecs_fargate_spot ? [true] : []
+    content {
+      capacity_provider = "FARGATE_SPOT"
+      weight            = 100
+    }
   }
 
   tags = local.tags

--- a/main.tf
+++ b/main.tf
@@ -373,7 +373,7 @@ data "aws_iam_policy_document" "ecs_tasks" {
 
     principals {
       type        = "Service"
-      identifiers = concat(["ecs-tasks.amazonaws.com"], var.trusted_principals)
+      identifiers = compact(distinct(concat(["ecs-tasks.amazonaws.com"], var.trusted_principals)))
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -364,7 +364,7 @@ data "aws_iam_policy_document" "ecs_tasks" {
 
     principals {
       type        = "Service"
-      identifiers = ["ecs-tasks.amazonaws.com"]
+      identifiers = concat(["ecs-tasks.amazonaws.com"], var.trusted_principals)
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ locals {
   alb_authenication_method = length(keys(var.alb_authenticate_oidc)) > 0 ? "authenticate-oidc" : length(keys(var.alb_authenticate_cognito)) > 0 ? "authenticate-cognito" : "forward"
 
   # Container definitions
-  container_definitions = var.custom_container_definitions == "" ? var.atlantis_bitbucket_user_token != "" ? module.container_definition_bitbucket.json_map_encoded_list : module.container_definition_github_gitlab.json_map_encoded_list : var.custom_container_definitions
+  container_definitions = var.custom_container_definitions == "" ? var.atlantis_bitbucket_user_token != "" ? jsonencode(concat([module.container_definition_bitbucket.json_map_object], var.extra_container_definitions)) : jsonencode(concat([module.container_definition_github_gitlab.json_map_object], var.extra_container_definitions)) : var.custom_container_definitions
 
   container_definition_environment = [
     {

--- a/modules/github-repository-webhook/README.md
+++ b/modules/github-repository-webhook/README.md
@@ -3,13 +3,16 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.7 |
+| github | >= 2.4.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| github | n/a |
+| github | >= 2.4.1 |
 
 ## Inputs
 

--- a/modules/github-repository-webhook/versions.tf
+++ b/modules/github-repository-webhook/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_version = ">= 0.12.7"
 
   required_providers {
-    aws    = ">= 2.68"
-    random = ">= 2.0"
+    github = ">= 2.4.1"
   }
 }

--- a/modules/gitlab-repository-webhook/README.md
+++ b/modules/gitlab-repository-webhook/README.md
@@ -3,7 +3,9 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
 
 ## Providers
 
@@ -18,7 +20,6 @@ No requirements.
 | atlantis\_allowed\_repo\_names | List of names of repositories which belong to the organization specified in `gitlab_organization` | `list(string)` | n/a | yes |
 | create\_gitlab\_repository\_webhook | Whether to create Gitlab repository webhook for Atlantis | `bool` | `true` | no |
 | gitlab\_base\_url | Gitlab base\_url use | `string` | `""` | no |
-| gitlab\_organization | Gitlab organization to use when creating webhook | `string` | `""` | no |
 | gitlab\_token | Gitlab token to use when creating webhook | `string` | `""` | no |
 | webhook\_secret | Webhook secret | `string` | `""` | no |
 | webhook\_url | Webhook URL | `string` | `""` | no |

--- a/modules/gitlab-repository-webhook/variables.tf
+++ b/modules/gitlab-repository-webhook/variables.tf
@@ -16,12 +16,6 @@ variable "gitlab_token" {
   default     = ""
 }
 
-variable "gitlab_organization" {
-  description = "Gitlab organization to use when creating webhook"
-  type        = string
-  default     = ""
-}
-
 variable "atlantis_allowed_repo_names" {
   description = "List of names of repositories which belong to the organization specified in `gitlab_organization`"
   type        = list(string)

--- a/modules/gitlab-repository-webhook/versions.tf
+++ b/modules/gitlab-repository-webhook/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    gitlab = {
+      source = "gitlabhq/gitlab"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -239,6 +239,12 @@ variable "policies_arn" {
   default     = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
+variable "ecs_fargate_spot" {
+  description = "Whether to run ECS Fargate Spot or not"
+  type        = bool
+  default     = false
+}
+
 variable "ecs_container_insights" {
   description = "Controls if ECS Cluster has container insights enabled"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -239,6 +239,12 @@ variable "policies_arn" {
   default     = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
+variable "trusted_principals" {
+  description = "A list of principals, in addition to ecs-tasks.amazonaws.com, that can assume the task role"
+  type        = list(string)
+  default     = []
+}
+
 variable "ecs_container_insights" {
   description = "Controls if ECS Cluster has container insights enabled"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -293,6 +293,12 @@ variable "custom_container_definitions" {
   default     = ""
 }
 
+variable "extra_container_definitions" {
+  description = "A list of valid container definitions provided as a single valid JSON document. These will be provided as supplimentary to the main Atlantis container definition"
+  type        = list(any)
+  default     = []
+}
+
 variable "entrypoint" {
   description = "The entry point that is passed to the container"
   type        = list(string)


### PR DESCRIPTION
At the moment, the only trusted entity to assume the task role
is the absolute minimum ecs-tasks.amazonaws.com
However sometimes it's convenient to add more principals.
For example in order to allow easy SSM access into the Fargate
task, ssm.amazonaws.com should be trusted too.

This commit allows module users to optionally define extra principals
that can assume the task role.